### PR TITLE
Fix parent assignment in build_tree()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,9 @@ Authors@R: c(
            comment = c(ORCID = "0000-0003-2555-8476")),
     person("Stefan", "Widgren", role = c("aut", "cre"),
            email = "stefan.widgren@gmail.com",
-           comment = c(ORCID = "0000-0001-5745-2284")))
+           comment = c(ORCID = "0000-0001-5745-2284")),
+    person("Carlijn", "Bogaardt", role = "ctb",
+           comment = c(ORCID = "0000-0002-9322-6978")))
 Description: Routines for epidemiological contact tracing
     and visualisation of network of contacts.
 License: EUPL

--- a/R/tree.R
+++ b/R/tree.R
@@ -53,7 +53,8 @@ build_tree <- function(network_structure) {
         for (lev in rev(seq_len(max(tree_in$level)))) {
             for (src in tree_in$node[tree_in$level == lev]) {
                 if (lev > 1) {
-                    i <- which(network_structure$direction == "in"
+                    i <- which(network_structure$source == src 
+                               & network_structure$direction == "in"
                                & network_structure$distance == lev)
                     dst <- network_structure$destination[i]
                     dst <- unique(dst)
@@ -83,7 +84,8 @@ build_tree <- function(network_structure) {
         for (lev in rev(seq_len(max(tree_out$level)))) {
             for (dst in tree_out$node[tree_out$level == lev]) {
                 if (lev > 1) {
-                    i <- which(network_structure$direction == "out"
+                    i <- which(network_structure$destination == dst
+                               & network_structure$direction == "out"
                                & network_structure$distance == lev)
                     src <- network_structure$source[i]
                     src <- unique(src)


### PR DESCRIPTION
Hi @stewid ,

build_tree() had a bug in it when it comes to assigning node parents, resulting in erroneous EpiContactTrace plots: at each level, all nodes are assigned one and the same “parent” node.

I've added two lines to fix this, resulting in a correct "tree". Illustrated using some fake UK movement data:

```
> cto <- Trace(md, "57/418/6011", "2019-05-01", 120)
> NetworkStructure(cto) %>% build_tree()
$ingoing
          node      parent level
1  57/418/6011        <NA>     0
2  12/927/6771 57/418/6011     1
3  47/479/9810 57/418/6011     1
4  62/245/8420 57/418/6011     1
5  32/560/2297 62/245/8420     2 # This has parent "62/245/8420" at lvl 1
6  45/654/1703 47/479/9810     2 # This has parent "47/479/9810" at lvl 1, previously this was the same as above
7  71/736/3034 62/245/8420     2
8  90/698/8684 47/479/9810     2
9  38/210/2235 71/736/3034     3
10 94/894/9933 71/736/3034     3
11 78/214/8249 38/210/2235     4
12 30/474/7569 78/214/8249     5

$outgoing
         node      parent level
1 57/418/6011        <NA>     0
2 41/119/3644 57/418/6011     1
3 90/335/6072 57/418/6011     1
4 20/857/9673 90/335/6072     2
5 99/409/1343 90/335/6072     2
```

But now when running plot() it throws an error from within position_tree(): 
```
> plot(cto) 
Error in if (move_distance > 0) { : missing value where TRUE/FALSE needed```